### PR TITLE
Recommend LibreHardwareMonitor

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,13 +27,13 @@ Features:
 
 ### Pre-requisites
 
-- Open Hardware Monitor is required to be running in the background with its HTTP port open.
-- Configure Open Hardware Monitor to use port 8085 ( see [openhardware.js line 19](https://github.com/atcurtis/streamdeck-ohs/blob/master/Sources/org.xiphis.ohs.sdPlugin/propertyinspector/js/openhardware.js#L19) )
+- Open Hardware Monitor/Libre Hardware Monitor is required to be running in the background with its HTTP port open.
+- Configure your Hardware Monitor to use port 8085 ( see [openhardware.js line 19](https://github.com/atcurtis/streamdeck-ohs/blob/master/Sources/org.xiphis.ohs.sdPlugin/propertyinspector/js/openhardware.js#L19) )
 
-### Where to find Open Hardware Monitor
-
-- "Official" source: [https://github.com/openhardwaremonitor/openhardwaremonitor](https://openhardwaremonitor.org/downloads/)
-- Active fork: [https://github.com/hexagon-oss/openhardwaremonitor/releases](https://github.com/hexagon-oss/openhardwaremonitor/releases)
+### Where to find Open Hardware Monitor/Libre Hardware Monitor
+- Libre Hardware Monitor (recommended): [https://github.com/LibreHardwareMonitor/LibreHardwareMonitor](https://github.com/LibreHardwareMonitor/LibreHardwareMonitor]
+- Official, outdated, Open Hardware Monitor source: [https://github.com/openhardwaremonitor/openhardwaremonitor](https://openhardwaremonitor.org/downloads/)
+- Active OHM-fork: [https://github.com/hexagon-oss/openhardwaremonitor/releases](https://github.com/hexagon-oss/openhardwaremonitor/releases)
 
 ## To-Do:
 


### PR DESCRIPTION
Recommend LibreHardwareMonitor, as it's the most active and stable OHM fork.